### PR TITLE
Update app.json to fix heroku deployment issue

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
   ],
   "repository": "https://github.com/strapi/strapi-heroku-template",
   "addons": [
-    "heroku-postgresql:hobby-dev"
+    "heroku-postgresql:mini"
   ],
   "image": "heroku/nodejs",
   "buildpacks": [


### PR DESCRIPTION
This fixes an issue with the auto deploy to heroku. heroku-postgresql:hobby-dev is no longer available.
![Screen Shot 2023-07-19 at 9 55 33 AM](https://github.com/strapi/strapi-heroku-template/assets/10416202/17ea988b-1885-4b7a-ba3a-5cbe03eccde3)
